### PR TITLE
add use of `become`

### DIFF
--- a/tasks/hostname.yml
+++ b/tasks/hostname.yml
@@ -13,3 +13,4 @@
         - hostname.j2
       paths:
         - ../templates
+  become: true

--- a/tasks/hosts.yml
+++ b/tasks/hosts.yml
@@ -14,6 +14,7 @@
       paths:
         - ../templates
   when: hosts_override_hosts_template is not defined
+  become: true
 
 - name: Set up /etc/hosts (override).
   template:
@@ -23,3 +24,4 @@
     group:  "{{ hosts_file_group }}"
     mode: 0644
   when: hosts_override_hosts_template is defined
+  become: true


### PR DESCRIPTION
The use of `become` is needed if you are provisioning using an Admin user (enabled to run `sudo`), especially useful when root ssh access is disallowed

An example case is when re-provisioning a vm which had the `root` access disabled after the first provisioning and had access managed via JumpCloud tags/users