### PR TITLE
Adds option to set hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Empty by default.
 hosts_all_hosts: List of all host entries. Just merges hosts_default_hosts and
 hosts_additional_hosts by default.
 
+hosts_hostname: The hostname that  will be given to the remote target (ie the
+contents of /etc/hostname). If left empty, it defaults to
+`inventory_hostname_short`.
+
 Example Playbook
 ----------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,4 +20,6 @@ hosts_additional_hosts: []
 
 hosts_all_hosts: "{{ hosts_default_hosts|union(hosts_additional_hosts) }}"
 
+hosts_hostname: ''
+
 hosts_file_group: root

--- a/tasks/hostname.yml
+++ b/tasks/hostname.yml
@@ -1,15 +1,11 @@
 ---
 
 - name: Set up /etc/hostname.
-  template:
-    src: "{{item}}"
-    dest: /etc/hostname
+  hostname:
+    name: "{{ hosts_hostname | default(inventory_hostname_short, true) }}"
+
+- name: Set group on /etc/hostname
+  file:
+    path: /etc/hostname
     owner: root
     group: "{{ hosts_file_group }}"
-    mode: 0644
-  with_first_found:
-    - files:
-        - "{{ 'hostname_' + inventory_hostname + '.j2' }}"
-        - hostname.j2
-      paths:
-        - ../templates

--- a/templates/hostname.j2
+++ b/templates/hostname.j2
@@ -1,1 +1,1 @@
-{{ inventory_hostname_short }}
+{{ hosts_hostname | default(inventory_hostname_short, true) }}

--- a/templates/hostname.j2
+++ b/templates/hostname.j2
@@ -1,1 +1,0 @@
-{{ hosts_hostname | default(inventory_hostname_short, true) }}


### PR DESCRIPTION
Setting by default the hostname of the target host to `inventory_hostname_short` is a bit restrictive. My use case is the installation of some software that expects a very specific hostname for the instance. However, I prefer to have this instance in my inventory with a different name to make sense to me. 

Also, in this PR, I removed the `/etc/hostname` template. The mechanism to override the template was not documented and not very usable as it was needed to place custom files in the role folder.