### PR TITLE
Add darwin support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
-  when: ansible_os_family == 'FreeBSD'
+  when: (ansible_os_family == 'FreeBSD' or ansible_os_family == 'Darwin')
 
 - include: hostname.yml
 - include: hosts.yml

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,0 +1,2 @@
+---
+hosts_file_group: wheel


### PR DESCRIPTION
Current version fails to modify /etc/hostname when target host is running OS X 10.14 (Mojave).
